### PR TITLE
encode query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Replaces all URLs in a string, matching the `origins` property of the initializa
 
 Note that:
  - The `origins` property can match only the start of the asset URL.
- - The query string part of the matched URL will not be encoded, so services like imgix that support transformation commands will still work. For example `http://resource1.com/images/bg/red.jpg?flip=v` will become `http://proxy.com/http%3A%2F%2Fresource1.com%2Fimages%2Fbg%2Fred.jpg?flip=v`.
 
 ```javascript
 // Preprocessor

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var SolidusAssetsProxy = function(options) {
   if (!(this instanceof SolidusAssetsProxy)) return new SolidusAssetsProxy(options);
 
   this.origins = options.origins.map(function(origin) {
-    // Match URL strings from origin up to the query string or ending delimiter
+    // Match URL strings from origin up to the ending delimiter
     var regexp = _.isRegExp(origin) ? origin.source : escapeRegExp(origin);
-    return new RegExp('(^|[\'"\\s\\(])(' + regexp + '.*?)($|[\\?\'"\\s\\)])', 'g');
+    return new RegExp('(^|[\'"\\s\\(])(' + regexp + '.*?)($|[\'"\\s\\)])', 'g');
   });
   this.proxy = options.proxy + (options.proxy.slice(-1) == '/' ? '' : '/');
 };

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('SolidusAssetsProxy', function() {
         \'http://p/https%3A%2F%2Fr%2Fb\' \
         http://p/https%3A%2F%2Fr%2Fc \
         (http://p/https%3A%2F%2Fr%2Fd) \
-        "http://p/https%3A%2F%2Fr%2Fa?a=b"';
+        "http://p/https%3A%2F%2Fr%2Fa%3Fa%3Db"';
       assert.equal(assets_proxy.proxyAssets(from), to);
     });
 


### PR DESCRIPTION
Encode query strings so that we can do something like `{{featured_image.source}}?fit=crop` without worrying if there is a preexisting query string on the image source URL. Since Imgix query strings probably won't be used in the original resource URLs anyway, this should work fine, and we can just append query strings with a `?` in the `.hbs` files. How does this look, @joanniclaborde?
